### PR TITLE
修正S1：增加因 QR code 資訊不一定能成功取得頁碼的處理方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ myClassID.txt
 output/
 __pycache__/
 log.txt
-107590060/
 rotated_*/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ myClassID.txt
 output/
 __pycache__/
 log.txt
-last_download_0604_1400.txt
+107590060/
+rotated_*/

--- a/s1_rotate_page.py
+++ b/s1_rotate_page.py
@@ -100,8 +100,6 @@ def get_skew_angle(qrcode_img) -> float:
 
     coords = np.column_stack(np.where(thresh > 0))
     angle = cv2.minAreaRect(coords)[-1] # (0, 90]
-    
-    # print(angle, end=" ")
         
     if angle > 45:
         angle = 90 - angle
@@ -121,7 +119,7 @@ def saveImage(image, now_page):
     cv2.imwrite('./{}/{}.png'.format(result_path, now_page), image)
     
 
-def rotate_img(file_path) -> bool:
+def rotate_img(file_path, index) -> bool:
     """主程式，以 QR Code 旋轉稿紙
     
     Keyword arguments:
@@ -153,6 +151,10 @@ def rotate_img(file_path) -> bool:
         now_page, bbox = qrcode_finder(left_top)
         IsRightBottom = False
     if bbox is None: return False
+    if now_page == '':
+        now_page = str(index + 1)
+        print(f'\nGet information from QR code failed, replace to "{now_page}.png", file path: {file_path}')
+        print(f'Warning: It may contained page error, please check it manually')
     
     # Calculate qrcode angle
     box = boxSize(bbox[0])
@@ -194,7 +196,7 @@ if __name__ == '__main__':
     allFileList = os.listdir(target_path)
     for index in tqdm(range(len(allFileList))):
         filePath = target_path + "/" + allFileList[index]
-        if not rotate_img(filePath):
+        if not rotate_img(filePath, index):
             errorList.append(allFileList[index])
             
     print("Rotate successfully")


### PR DESCRIPTION
發現 qrcode_finder() 就算能找出完整的 QRcode 但不一定能取得頁碼，zoom_qrcode_finder() 雖然有提高成功率，但`測試對象`仍有10% 左右機率出現找不到頁碼的問題。

增加了例外處理方式：傳入 讀取文件順序index，若找不到頁碼，用原本的方式取代，輸出警告讓使用者檢查有無錯誤

